### PR TITLE
Update whatsapp.js

### DIFF
--- a/whatsapp.js
+++ b/whatsapp.js
@@ -102,7 +102,7 @@ function onWebViewMessage(msg)
 
 function handleKeyDown(event)
 {
-  if (event.ctrlKey)
+  if (event.ctrlKey && !event.altKey)
   {
     switch (event.keyCode)
     {


### PR DESCRIPTION
Prevent AltGr + q to quit application. It is needed in International Keyboard Layout (USA) to type the German character "ä".

See http://stackoverflow.com/questions/10657346/detect-alt-gr-alt-graph-modifier-on-key-press for behavior in Chrome.
